### PR TITLE
Refactor project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ Usage:
   eswatch [options] [entry points]
 
 Options:
-  --watch   Directory/files to watch (supports glob patterns)
-  --clear   Clear screen on each reload
-  --entry   Entry point for the build
-  --outdir  The output directory (for multiple entry points)
-  --run     Execute the output script right after each build
+  --bundle      Bundle all dependencies into the output files
+  --external    Exclude specific modules from the bundle
+  --format      Output format
+  --splitting   Enable code splitting
+  --watch       Directory/files to watch (supports glob patterns)
+  --clear       Clear screen on each reload
+  --entry       Entry point for the build
+  --outdir      The output directory (for multiple entry points)
+  --run         Execute the output script right after each build
 ```

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,4 +1,7 @@
 import inquirer from 'inquirer'
+import { message } from './message'
+
+message()
 
 inquirer
   .prompt([

--- a/example/message.ts
+++ b/example/message.ts
@@ -1,0 +1,1 @@
+export const message = () => console.log('Hey there! What`s your name?')

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,35 +1,42 @@
 #!/usr/bin/env node
+
+// src/index.ts
+import minimist2 from "minimist";
+
+// src/validateEntryPoints.ts
+import {existsSync} from "fs";
+const validateEntryPoints = (options2) => {
+  const missingEntryPoint = options2._.length < 1 && !options2.entry;
+  const invalidEntryPoint = !options2._.every((entryPoint) => existsSync(entryPoint));
+  if (missingEntryPoint)
+    throw new Error("Missing entry point");
+  else if (invalidEntryPoint)
+    throw new Error("Invalid entry point");
+};
+
+// src/watchAndBuild.ts
+import path2 from "path";
 import readline2 from "readline";
-import path2, {dirname} from "path";
+import esbuild2 from "esbuild";
 import {fileURLToPath} from "url";
 import {spawn} from "child_process";
-import minimist2 from "minimist";
-import esbuild2 from "esbuild";
-import {existsSync} from "fs";
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const options = minimist2(process.argv.slice(2));
-const missingEntryPoint = options._.length < 1 && !options.entry;
-const invalidEntryPoint = !options._.every((entryPoint) => existsSync(entryPoint));
-if (missingEntryPoint)
-  throw new Error("Missing entry point");
-else if (invalidEntryPoint)
-  throw new Error("Invalid entry point");
+const __dirname = path2.dirname(fileURLToPath(import.meta.url));
 let child;
 const rl = readline2.createInterface({
   input: process.stdin,
   output: process.stdout
 });
-const watchAndBuild = async () => {
-  const entryPoints = options.entry ? [options.entry] : options._;
-  const outdir = options.outdir || path2.join(__dirname, "build");
+const watchAndBuild = async (options2) => {
+  const entryPoints = options2.entry ? [options2.entry] : options2._;
+  const outdir = options2.outdir || path2.join(__dirname, "build");
   child && child.kill();
   const service = await esbuild2.startService();
-  options.clear && console.clear();
+  options2.clear && console.clear();
   await service.build({entryPoints, outdir});
   return new Promise((resolve) => {
-    if (options.run) {
+    if (options2.run) {
       rl.pause();
-      const commandToRun = typeof options.run === "string" ? options.run : `node ${outdir}`;
+      const commandToRun = typeof options2.run === "string" ? options2.run : `node ${outdir}`;
       const commandName = commandToRun.split(" ").shift();
       const commandParameters = commandToRun.split(" ").slice(1);
       child = spawn(commandName, commandParameters, {stdio: "inherit"});
@@ -42,4 +49,8 @@ const watchAndBuild = async () => {
     }
   });
 };
-options.watch ? import("chokidar").then(({default: chokidar}) => chokidar.watch(options.watch).on("ready", async () => watchAndBuild()).on("change", async () => watchAndBuild())) : watchAndBuild();
+
+// src/index.ts
+const options = minimist2(process.argv.slice(2));
+validateEntryPoints(options);
+options.watch ? import("chokidar").then(({default: chokidar}) => chokidar.watch(options.watch).on("ready", async () => watchAndBuild(options)).on("change", async () => watchAndBuild(options))) : watchAndBuild(options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ import path2 from "path";
 import readline2 from "readline";
 import {fileURLToPath} from "url";
 import {spawn} from "child_process";
+import {builtinModules} from "module";
 import esbuild2 from "esbuild";
 
 // src/getDependencies.ts
@@ -37,7 +38,6 @@ const getDependencies = async () => {
 };
 
 // src/watchAndBuild.ts
-import {builtinModules} from "module";
 const __dirname = path2.dirname(fileURLToPath(import.meta.url));
 let child;
 const rl = readline2.createInterface({
@@ -53,7 +53,7 @@ const watchAndBuild = async (options2) => {
   options2.clear && console.clear();
   await service.build({
     bundle: options2.bundle,
-    external: [...dependencies, ...builtinModules],
+    ...options2.bundle && {external: [...dependencies, ...builtinModules]},
     format: options2.format,
     splitting: options2.splitting,
     entryPoints,

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,9 +17,27 @@ const validateEntryPoints = (options2) => {
 // src/watchAndBuild.ts
 import path2 from "path";
 import readline2 from "readline";
-import esbuild2 from "esbuild";
 import {fileURLToPath} from "url";
 import {spawn} from "child_process";
+import esbuild2 from "esbuild";
+
+// src/getDependencies.ts
+import {readFileSync} from "fs";
+import findUp from "find-up";
+const getDependencies = async () => {
+  const packageJsonPath = await findUp("package.json");
+  if (packageJsonPath) {
+    const packageJsonString = readFileSync(packageJsonPath, {encoding: "utf-8"});
+    const packageJson = JSON.parse(packageJsonString);
+    const dependencies = Object.keys(packageJson.dependencies);
+    return dependencies;
+  } else {
+    return [];
+  }
+};
+
+// src/watchAndBuild.ts
+import {builtinModules} from "module";
 const __dirname = path2.dirname(fileURLToPath(import.meta.url));
 let child;
 const rl = readline2.createInterface({
@@ -29,10 +47,18 @@ const rl = readline2.createInterface({
 const watchAndBuild = async (options2) => {
   const entryPoints = options2.entry ? [options2.entry] : options2._;
   const outdir = options2.outdir || path2.join(__dirname, "build");
+  const dependencies = await getDependencies();
   child && child.kill();
   const service = await esbuild2.startService();
   options2.clear && console.clear();
-  await service.build({entryPoints, outdir});
+  await service.build({
+    bundle: options2.bundle,
+    external: [...dependencies, ...builtinModules],
+    format: options2.format,
+    splitting: options2.splitting,
+    entryPoints,
+    outdir
+  });
   return new Promise((resolve) => {
     if (options2.run) {
       rl.pause();

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn lint",
+      "pre-commit": "yarn lint && git add .",
       "pre-push": "yarn lint"
     }
   },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "chokidar": "^3.4.2",
     "esbuild": "^0.7.13",
+    "find-up": "^5.0.0",
     "inquirer": "^7.3.3",
     "minimist": "^1.2.5"
   }

--- a/package.json
+++ b/package.json
@@ -24,21 +24,21 @@
     }
   },
   "devDependencies": {
-    "@types/eslint": "^7.2.0",
+    "@types/eslint": "^7.2.4",
     "@types/inquirer": "^7.3.1",
     "@types/minimist": "^1.2.0",
-    "@types/node": "^14.0.27",
-    "@typescript-eslint/eslint-plugin": "^3.8.0",
-    "@typescript-eslint/parser": "^3.8.0",
-    "eslint": "^7.6.0",
-    "eslint-plugin-import": "^2.22.0",
-    "eswatch": "^0.5.0",
-    "husky": "^4.2.5",
-    "typescript": "^3.9.7"
+    "@types/node": "^14.14.2",
+    "@typescript-eslint/eslint-plugin": "^4.5.0",
+    "@typescript-eslint/parser": "^4.5.0",
+    "eslint": "^7.11.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eswatch": "^0.5.1",
+    "husky": "^4.3.0",
+    "typescript": "^4.0.3"
   },
   "dependencies": {
-    "chokidar": "^3.4.2",
-    "esbuild": "^0.7.13",
+    "chokidar": "^3.4.3",
+    "esbuild": "^0.7.19",
     "find-up": "^5.0.0",
     "inquirer": "^7.3.3",
     "minimist": "^1.2.5"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/henriquehbr/eswatch"
   },
   "scripts": {
-    "dev": "eswatch --clear --outdir ./lib --watch ./src/**/* --entry ./src/index.ts --run \"node lib --outdir ./lib/example-build --clear --run --watch ./example/**/* ./example/index.ts\"",
+    "dev": "eswatch --bundle --format esm --splitting --clear --outdir ./lib --watch ./src/**/* ./src/index.ts --run \"node lib --bundle --format esm --outdir ./lib/example-build --clear --run --watch ./example/**/* ./example/index.ts\"",
     "lint": "eslint --fix \"src/**/*.ts\" && tsc --noEmit -p ."
   },
   "husky": {
@@ -32,7 +32,7 @@
     "@typescript-eslint/parser": "^3.8.0",
     "eslint": "^7.6.0",
     "eslint-plugin-import": "^2.22.0",
-    "eswatch": "^0.3.0",
+    "eswatch": "^0.5.0",
     "husky": "^4.2.5",
     "typescript": "^3.9.7"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eswatch",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "main": "lib/index.js",
   "author": "Henrique Borges <henriqueborgeshbr@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eswatch",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "lib/index.js",
   "author": "Henrique Borges <henriqueborgeshbr@gmail.com>",
   "license": "MIT",

--- a/src/getDependencies.ts
+++ b/src/getDependencies.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'fs'
+import findUp from 'find-up'
+
+export const getDependencies = async () => {
+  const packageJsonPath = await findUp('package.json')
+  if (packageJsonPath) {
+    const packageJsonString = readFileSync(packageJsonPath, { encoding: 'utf-8' })
+    const packageJson = JSON.parse(packageJsonString)
+    const dependencies = Object.keys(packageJson.dependencies)
+    return dependencies
+  } else {
+    return []
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import type { CLIFlags } from './types'
 import minimist from 'minimist'
+import type { CLIFlags } from './types'
 import { validateEntryPoints } from './validateEntryPoints'
 import { watchAndBuild } from './watchAndBuild'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,71 +1,19 @@
 #!/usr/bin/env node
-import readline from 'readline'
-import path, { dirname } from 'path'
-import { fileURLToPath } from 'url'
-import { ChildProcess, spawn } from 'child_process'
-import { existsSync } from 'fs'
+import type { CLIFlags } from './types'
 import minimist from 'minimist'
-import esbuild from 'esbuild'
+import { validateEntryPoints } from './validateEntryPoints'
+import { watchAndBuild } from './watchAndBuild'
 
-interface LiveReloadOptions {
-  watch: string | readonly string[]
-  clear?: boolean
-  entry: string
-  outdir?: string
-  run?: boolean
-}
+const options = minimist<CLIFlags>(process.argv.slice(2))
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const options = minimist<LiveReloadOptions>(process.argv.slice(2))
-
-// TODO: put entry point validation on a separated util module
-const missingEntryPoint = options._.length < 1 && !options.entry
-const invalidEntryPoint = !options._.every(entryPoint => existsSync(entryPoint))
-if (missingEntryPoint)
-  throw new Error('Missing entry point')
-else if (invalidEntryPoint)
-  throw new Error('Invalid entry point')
-
-let child: ChildProcess
-
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout
-})
-
-const watchAndBuild = async () => {
-  // TODO: remove `options.entry` on 1.0
-  const entryPoints = options.entry ? [options.entry] : options._
-  // This is set to the built library inside node_modules
-  const outdir = options.outdir || path.join(__dirname, 'build')
-  child && child.kill()
-  const service = await esbuild.startService()
-  options.clear && console.clear()
-  // TODO: switch to yargs later, as minimist doesn't support array options on
-  await service.build({ entryPoints, outdir })
-  return new Promise<void>(resolve => {
-    if (options.run) {
-      rl.pause()
-      const commandToRun = typeof options.run === 'string' ? options.run : `node ${outdir}`
-      const commandName = commandToRun.split(' ').shift()!
-      const commandParameters = commandToRun.split(' ').slice(1)
-      child = spawn(commandName, commandParameters, { stdio: 'inherit' })
-      child.on('close', () => {
-        rl.resume()
-        resolve()
-      })
-    } else {
-      resolve()
-    }
-  })
-}
+validateEntryPoints(options)
 
 options.watch
   ? import('chokidar')
     .then(({ default: chokidar }) =>
       chokidar
         .watch(options.watch)
-        .on('ready', async () => watchAndBuild())
-        .on('change', async () => watchAndBuild())
+        .on('ready', async () => watchAndBuild(options))
+        .on('change', async () => watchAndBuild(options))
     )
-  : watchAndBuild()
+  : watchAndBuild(options)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+import type { ParsedArgs } from 'minimist'
+
+export interface CLIFlags extends ParsedArgs {
+  watch: string | readonly string[]
+  clear?: boolean
+  entry: string
+  outdir?: string
+  run?: boolean
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,10 @@
 import type { ParsedArgs } from 'minimist'
 
 export interface CLIFlags extends ParsedArgs {
+  bundle: boolean
+  external: string[]
+  format: 'cjs' | 'esm' | 'iife'
+  splitting: boolean
   watch: string | readonly string[]
   clear?: boolean
   entry: string

--- a/src/validateEntryPoints.ts
+++ b/src/validateEntryPoints.ts
@@ -1,0 +1,13 @@
+import { existsSync } from 'fs'
+import type { CLIFlags } from 'types'
+
+export type ValidateEntryPoints = (options: CLIFlags) => void
+
+export const validateEntryPoints: ValidateEntryPoints = options => {
+  const missingEntryPoint = options._.length < 1 && !options.entry
+  const invalidEntryPoint = !options._.every(entryPoint => existsSync(entryPoint))
+  if (missingEntryPoint)
+    throw new Error('Missing entry point')
+  else if (invalidEntryPoint)
+    throw new Error('Invalid entry point')
+}

--- a/src/watchAndBuild.ts
+++ b/src/watchAndBuild.ts
@@ -1,8 +1,8 @@
 import path from 'path'
 import readline from 'readline'
-import esbuild from 'esbuild'
 import { fileURLToPath } from 'url'
 import { ChildProcess, spawn } from 'child_process'
+import esbuild from 'esbuild'
 import type { CLIFlags } from 'types'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))

--- a/src/watchAndBuild.ts
+++ b/src/watchAndBuild.ts
@@ -1,0 +1,43 @@
+import path from 'path'
+import readline from 'readline'
+import esbuild from 'esbuild'
+import { fileURLToPath } from 'url'
+import { ChildProcess, spawn } from 'child_process'
+import type { CLIFlags } from 'types'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+let child: ChildProcess
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+})
+
+export type WatchAndBuild = (options: CLIFlags) => Promise<void>
+
+export const watchAndBuild: WatchAndBuild = async options => {
+  // TODO: remove `options.entry` on 1.0
+  const entryPoints = options.entry ? [options.entry] : options._
+  // This is set to the built library inside node_modules
+  const outdir = options.outdir || path.join(__dirname, 'build')
+  child && child.kill()
+  const service = await esbuild.startService()
+  options.clear && console.clear()
+  await service.build({ entryPoints, outdir })
+  return new Promise(resolve => {
+    if (options.run) {
+      rl.pause()
+      const commandToRun = typeof options.run === 'string' ? options.run : `node ${outdir}`
+      const commandName = commandToRun.split(' ').shift()!
+      const commandParameters = commandToRun.split(' ').slice(1)
+      child = spawn(commandName, commandParameters, { stdio: 'inherit' })
+      child.on('close', () => {
+        rl.resume()
+        resolve()
+      })
+    } else {
+      resolve()
+    }
+  })
+}

--- a/src/watchAndBuild.ts
+++ b/src/watchAndBuild.ts
@@ -29,7 +29,7 @@ export const watchAndBuild: WatchAndBuild = async options => {
   options.clear && console.clear()
   await service.build({
     bundle: options.bundle,
-    external: [...dependencies, ...builtinModules],
+    ...(options.bundle && { external: [...dependencies, ...builtinModules] }),
     format: options.format,
     splitting: options.splitting,
     entryPoints,

--- a/yarn.lock
+++ b/yarn.lock
@@ -729,6 +729,14 @@ find-up@^4.0.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 find-versions@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-3.2.0.tgz#10297f98030a786829681690545ef659ed1d254e"
@@ -1057,6 +1065,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
@@ -1201,6 +1216,13 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz#1664e010af3cadc681baafd3e2a437be7b0fb5fe"
+  integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -1214,6 +1236,13 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-try@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,13 +659,14 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-eswatch@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/eswatch/-/eswatch-0.3.0.tgz#de918ad738acaa16155494419399f0f88b84c3cb"
-  integrity sha512-dHiemeaVR3GoOlZYSWcFlKdekdebrllCJnOZpKzRHYca6paW43GXvn88Olo30Sl8ckWn7/3LBMFcxtW+yiFcFw==
+eswatch@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/eswatch/-/eswatch-0.5.0.tgz#2ae526d35c282cdfb127d6575e9dfb2ff5e6b994"
+  integrity sha512-84QepXwDowLs9TKXuv9uUhcxQxoqnkKrA0tdLrsq74PHBmS8FkumW3KA/uJQKRAdL4q6J1DcuzSduAF8WwNzFg==
   dependencies:
     chokidar "^3.4.2"
     esbuild "^0.7.13"
+    find-up "^5.0.0"
     inquirer "^7.3.3"
     minimist "^1.2.5"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,20 +39,36 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.3"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.3"
+    fastq "^1.6.0"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/eslint-visitor-keys@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
-  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
-
-"@types/eslint@^7.2.0":
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.2.tgz#c88426b896efeb0b2732a92431ce8aa7ec0dee61"
-  integrity sha512-psWuwNXuKR2e6vMU5d2qH0Kqzrb2Zxwk+uBCF2LsyEph+Nex3lFIPMJXwxfGesdtJM2qtjKoCYsyh76K3x9wLg==
+"@types/eslint@^7.2.4":
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.4.tgz#d12eeed7741d2491b69808576ac2d20c14f74c41"
+  integrity sha512-YCY4kzHMsHoyKspQH+nwSe+70Kep7Vjt2X+dZe5Vs2vkRudqtoFoUIv1RlJmZB8Hbp7McneupoZij4PadxsK5Q==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
@@ -85,10 +101,15 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
-"@types/node@*", "@types/node@^14.0.27":
+"@types/node@*":
   version "14.11.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.1.tgz#56af902ad157e763f9ba63d671c39cda3193c835"
   integrity sha512-oTQgnd0hblfLsJ6BvJzzSL+Inogp3lq9fGgqRkMB/ziKMgEUaFl801OncOzUmalfzt14N0oPHMK47ipl+wbTIw==
+
+"@types/node@^14.14.2":
+  version "14.14.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.2.tgz#d25295f9e4ca5989a2c610754dc02a9721235eeb"
+  integrity sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -102,65 +123,75 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@^3.8.0":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.10.1.tgz#7e061338a1383f59edc204c605899f93dc2e2c8f"
-  integrity sha512-PQg0emRtzZFWq6PxBcdxRH3QIQiyFO3WCVpRL3fgj5oQS3CDs3AeAKfv4DxNhzn8ITdNJGJ4D3Qw8eAJf3lXeQ==
+"@typescript-eslint/eslint-plugin@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.5.0.tgz#4ff9c1d8535ae832e239f0ef6d7210592d9b0b07"
+  integrity sha512-mjb/gwNcmDKNt+6mb7Aj/TjKzIJjOPcoCJpjBQC9ZnTRnBt1p4q5dJSSmIqAtsZ/Pff5N+hJlbiPc5bl6QN4OQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "3.10.1"
+    "@typescript-eslint/experimental-utils" "4.5.0"
+    "@typescript-eslint/scope-manager" "4.5.0"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz#e179ffc81a80ebcae2ea04e0332f8b251345a686"
-  integrity sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==
+"@typescript-eslint/experimental-utils@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.5.0.tgz#547fe1158609143ce60645383aa1d6f83ada28df"
+  integrity sha512-bW9IpSAKYvkqDGRZzayBXIgPsj2xmmVHLJ+flGSoN0fF98pGoKFhbunIol0VF2Crka7z984EEhFi623Rl7e6gg==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/types" "3.10.1"
-    "@typescript-eslint/typescript-estree" "3.10.1"
+    "@typescript-eslint/scope-manager" "4.5.0"
+    "@typescript-eslint/types" "4.5.0"
+    "@typescript-eslint/typescript-estree" "4.5.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^3.8.0":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.10.1.tgz#1883858e83e8b442627e1ac6f408925211155467"
-  integrity sha512-Ug1RcWcrJP02hmtaXVS3axPPTTPnZjupqhgj+NnZ6BCkwSImWk/283347+x9wN+lqOdK9Eo3vsyiyDHgsmiEJw==
+"@typescript-eslint/parser@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.5.0.tgz#b2d659f25eec0041c7bc5660b91db1eefe8d7122"
+  integrity sha512-xb+gmyhQcnDWe+5+xxaQk5iCw6KqXd8VQxGiTeELTMoYeRjpocZYYRP1gFVM2C8Yl0SpUvLa1lhprwqZ00w3Iw==
   dependencies:
-    "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "3.10.1"
-    "@typescript-eslint/types" "3.10.1"
-    "@typescript-eslint/typescript-estree" "3.10.1"
-    eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/types@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
-  integrity sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==
-
-"@typescript-eslint/typescript-estree@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz#fd0061cc38add4fad45136d654408569f365b853"
-  integrity sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==
-  dependencies:
-    "@typescript-eslint/types" "3.10.1"
-    "@typescript-eslint/visitor-keys" "3.10.1"
+    "@typescript-eslint/scope-manager" "4.5.0"
+    "@typescript-eslint/types" "4.5.0"
+    "@typescript-eslint/typescript-estree" "4.5.0"
     debug "^4.1.1"
-    glob "^7.1.6"
+
+"@typescript-eslint/scope-manager@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.5.0.tgz#8dfd53c3256d4357e7d66c2fc8956835f4d239be"
+  integrity sha512-C0cEO0cTMPJ/w4RA/KVe4LFFkkSh9VHoFzKmyaaDWAnPYIEzVCtJ+Un8GZoJhcvq+mPFXEsXa01lcZDHDG6Www==
+  dependencies:
+    "@typescript-eslint/types" "4.5.0"
+    "@typescript-eslint/visitor-keys" "4.5.0"
+
+"@typescript-eslint/types@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.5.0.tgz#98256e07bad1c8d15d0c9627ebec82fd971bb3c3"
+  integrity sha512-n2uQoXnyWNk0Les9MtF0gCK3JiWd987JQi97dMSxBOzVoLZXCNtxFckVqt1h8xuI1ix01t+iMY4h4rFMj/303g==
+
+"@typescript-eslint/typescript-estree@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.5.0.tgz#d50cf91ae3a89878401111031eb6fb6d03554f64"
+  integrity sha512-gN1mffq3zwRAjlYWzb5DanarOPdajQwx5MEWkWCk0XvqC8JpafDTeioDoow2L4CA/RkYZu7xEsGZRhqrTsAG8w==
+  dependencies:
+    "@typescript-eslint/types" "4.5.0"
+    "@typescript-eslint/visitor-keys" "4.5.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
     is-glob "^4.0.1"
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz#cd4274773e3eb63b2e870ac602274487ecd1e931"
-  integrity sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==
+"@typescript-eslint/visitor-keys@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.5.0.tgz#b59f26213ac597efe87f6b13cf2aabee70542af0"
+  integrity sha512-UHq4FSa55NDZqscRU//O5ROFhHa9Hqn9KWTEvJGTArtTQp5GKv9Zqf6d/Q3YXXcFv4woyBml7fJQlQ+OuqRcHA==
   dependencies:
-    eslint-visitor-keys "^1.1.0"
+    "@typescript-eslint/types" "4.5.0"
+    eslint-visitor-keys "^2.0.0"
 
 acorn-jsx@^5.2.0:
   version "5.3.1"
@@ -243,6 +274,11 @@ array-includes@^3.1.1:
     es-abstract "^1.17.0"
     is-string "^1.0.5"
 
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
 array.prototype.flat@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
@@ -274,7 +310,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@~3.0.2:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -320,6 +356,21 @@ chokidar@^3.4.2:
     is-glob "~4.0.1"
     normalize-path "~3.0.0"
     readdirp "~3.4.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
+chokidar@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
+  integrity sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
   optionalDependencies:
     fsevents "~2.1.2"
 
@@ -425,6 +476,13 @@ define-properties@^1.1.3:
   dependencies:
     object-keys "^1.0.12"
 
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -513,12 +571,17 @@ esbuild@^0.7.13:
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.7.13.tgz#ca614002e70814d548dd3243eb3ccc5d93833112"
   integrity sha512-IHBqE0blYhBw3fSgaQOHI1hdxq5OJgzdU/Tg0FPIZyag6eHCB5I8wirz1Oyse7W+TwCcFeCxMNLhdyjzdFACcw==
 
+esbuild@^0.7.19:
+  version "0.7.19"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.7.19.tgz#6f8b94445e06f8bf6125183a877de6046c965abc"
+  integrity sha512-0Ur8ZtuRPwJMj4+VjRLqn5z88WXf+2etZhe4dBA6eYFcdviQefb+Vrd59cTk0VXg08NU/BnAMkalCMHI8lig/A==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-import-resolver-node@^0.3.3:
+eslint-import-resolver-node@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
   integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
@@ -534,17 +597,17 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-import@^2.22.0:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"
-  integrity sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==
+eslint-plugin-import@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
+  integrity sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
   dependencies:
     array-includes "^3.1.1"
     array.prototype.flat "^1.2.3"
     contains-path "^0.1.0"
     debug "^2.6.9"
     doctrine "1.5.0"
-    eslint-import-resolver-node "^0.3.3"
+    eslint-import-resolver-node "^0.3.4"
     eslint-module-utils "^2.6.0"
     has "^1.0.3"
     minimatch "^3.0.4"
@@ -553,7 +616,7 @@ eslint-plugin-import@^2.22.0:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
-eslint-scope@^5.0.0, eslint-scope@^5.1.0:
+eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -573,10 +636,15 @@ eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
-eslint@^7.6.0:
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.9.0.tgz#522aeccc5c3a19017cf0cb46ebfd660a79acf337"
-  integrity sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==
+eslint-visitor-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+
+eslint@^7.11.0:
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.11.0.tgz#aaf2d23a0b5f1d652a08edacea0c19f7fadc0b3b"
+  integrity sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@eslint/eslintrc" "^0.1.3"
@@ -586,9 +654,9 @@ eslint@^7.6.0:
     debug "^4.0.1"
     doctrine "^3.0.0"
     enquirer "^2.3.5"
-    eslint-scope "^5.1.0"
+    eslint-scope "^5.1.1"
     eslint-utils "^2.1.0"
-    eslint-visitor-keys "^1.3.0"
+    eslint-visitor-keys "^2.0.0"
     espree "^7.3.0"
     esquery "^1.2.0"
     esutils "^2.0.2"
@@ -659,10 +727,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-eswatch@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/eswatch/-/eswatch-0.5.0.tgz#2ae526d35c282cdfb127d6575e9dfb2ff5e6b994"
-  integrity sha512-84QepXwDowLs9TKXuv9uUhcxQxoqnkKrA0tdLrsq74PHBmS8FkumW3KA/uJQKRAdL4q6J1DcuzSduAF8WwNzFg==
+eswatch@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/eswatch/-/eswatch-0.5.1.tgz#7b5a08df40419ba938bbca972820bd6ed023db91"
+  integrity sha512-hWOPfe+L+qOArGq4tRRSkH7JpJKlF91gVHb6ynaKhQXBK06P5vxRUVI9DNneauUt7ewUVkTSUc2pYEoBJ+zoEQ==
   dependencies:
     chokidar "^3.4.2"
     esbuild "^0.7.13"
@@ -684,6 +752,18 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-glob@^3.1.1:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
+  integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -693,6 +773,13 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fastq@^1.6.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.8.0.tgz#550e1f9f59bbc65fe185cb6a9b4d95357107f481"
+  integrity sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==
+  dependencies:
+    reusify "^1.0.4"
 
 figures@^3.0.0:
   version "3.2.0"
@@ -779,14 +866,14 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-glob-parent@^5.0.0, glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.3, glob@^7.1.6:
+glob@^7.1.3:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -804,6 +891,18 @@ globals@^12.1.0:
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
+
+globby@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
+  integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
 
 graceful-fs@^4.1.2:
   version "4.2.4"
@@ -837,7 +936,7 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
   integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
 
-husky@^4.2.5:
+husky@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.0.tgz#0b2ec1d66424e9219d359e26a51c58ec5278f0de"
   integrity sha512-tTMeLCLqSBqnflBZnlVDhpaIMucSGaYyX6855jM4AguGeWCeSzNdb1mfyWduTZ3pe3SJVvVWGL0jO1iKZVPfTA==
@@ -864,6 +963,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.1.4:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.2.1"
@@ -1077,6 +1181,19 @@ lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -1316,7 +1433,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-picomatch@^2.0.4, picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -1386,6 +1503,13 @@ readdirp@~3.4.0:
   dependencies:
     picomatch "^2.2.1"
 
+readdirp@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
+
 regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
@@ -1411,6 +1535,11 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
@@ -1422,6 +1551,11 @@ run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
+
+run-parallel@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 rxjs@^6.4.0, rxjs@^6.6.0:
   version "6.6.3"
@@ -1662,10 +1796,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
 uri-js@^4.2.2:
   version "4.4.0"


### PR DESCRIPTION
This PR aims to split the core functionality into smaller more modules, in order to make the source code easier to read, maintain and implement new features

```
.
└── eswatch/
    └── src/
        ├── getDependencies.ts
        ├── index.ts
        ├── types.ts
        ├── validateEntryPoints.ts
        └── watchAndBuild.ts
```

Due to the small number of utils functions, all of them were directly added to the `src` directory instead of having their own `utils` folder, this may change later, but for now, i decided to keep this architecture as-is